### PR TITLE
Add secure backend scaffolding and docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# CollegeFantasyFootball
-College Fantasy Football Project
+# College Fantasy Football
+
+A full-stack concept for a college fantasy football platform covering Division I FBS and FCS players. The backend is written in C++ and the frontend uses lightweight HTML/CSS/JavaScript.
+
+## Structure
+- `docs/architecture.md` — architecture overview and roadmap.
+- `backend/` — C++ backend scaffold (Drogon-ready) with CMake config.
+- `frontend/` — static UI prototype for live scores, player search, and league summary.
+
+## Quickstart
+1. Review `docs/architecture.md` for the proposed system design.
+2. Build the backend (requires Drogon and CMake):
+   ```bash
+   cmake -S backend -B backend/build -DDROGON_FOUND=ON
+   cmake --build backend/build
+   ./backend/build/college_ff_server
+   ```
+   - Environment variables: `PORT` (default `8080`), `JWT_SECRET` (required for secure endpoints), optional `SSL_CERT_FILE`/`SSL_KEY_FILE` for HTTPS, and `ALLOWED_ORIGINS` (comma-separated) for CORS.
+3. Serve the frontend locally (any static server, e.g., `python -m http.server` from `frontend/`).
+4. Optional: run everything via Docker for local testing:
+   ```bash
+   docker compose up --build
+   ```
+   - Backend available at `http://localhost:8080`.
+   - Frontend available at `http://localhost:3000` (includes `test.html` to hit the secure ping endpoint).
+
+## Roadmap
+- Implement auth, league creation, player search, and draft APIs in C++.
+- Wire the frontend to real backend endpoints for live scores and player search.
+- Add data ingestion for schedules, rosters, and live stats.

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.15)
+project(college_fantasy_football LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Drogon can be fetched via FetchContent or provided by the system.
+# To keep this scaffold lightweight, we do not fetch dependencies automatically.
+# Define DROGON_FOUND to ON if Drogon is available in your environment.
+
+if (DROGON_FOUND)
+    find_package(Drogon CONFIG REQUIRED)
+endif()
+
+add_executable(college_ff_server
+    src/main.cpp
+)
+
+target_include_directories(college_ff_server PRIVATE src)
+
+if (DROGON_FOUND)
+    target_link_libraries(college_ff_server PRIVATE Drogon::Drogon)
+else()
+    message(WARNING "Drogon not found; building a stub server without HTTP bindings.")
+endif()

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,29 @@
+# Backend container for local testing
+FROM debian:bookworm as build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libjsoncpp-dev \
+    uuid-dev \
+    zlib1g-dev \
+    libssl-dev \
+    libdrogon-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN cmake -S . -B build -DDROGON_FOUND=ON \
+    && cmake --build build --target college_ff_server -- -j$(nproc)
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y libssl3 && rm -rf /var/lib/apt/lists/*
+WORKDIR /srv
+COPY --from=build /app/build/college_ff_server /srv/college_ff_server
+EXPOSE 8080
+
+ENV PORT=8080
+CMD ["/srv/college_ff_server"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,43 @@
+# Backend (C++)
+
+This directory contains the C++ backend for the College Fantasy Football platform.
+
+## Proposed stack
+- **Framework:** [Drogon](https://github.com/drogonframework/drogon) (C++17 HTTP/WebSocket/ORM)
+- **Database:** PostgreSQL (with Drogon ORM) + Redis for caching/sessions
+- **Build:** CMake 3.15+
+
+If Drogon is unavailable in your environment, Crow or Pistache are viable alternatives; the structure below remains similar.
+
+## Building (example with Drogon)
+```bash
+cmake -S . -B build
+cmake --build build
+./build/college_ff_server
+```
+
+### Docker (local testing)
+```bash
+docker build -t college-ff-backend .
+docker run --rm -p 8080:8080 -e JWT_SECRET=dev-secret-token college-ff-backend
+```
+
+## Directory structure
+- `src/main.cpp`: Entry point; wires HTTP routes and health checks.
+- `src/routes/`: Route handlers grouped by domain (auth, leagues, players, drafts, waivers, lineups, scoring).
+- `src/models/`: Data models and mappers (if using ORM).
+- `src/services/`: Business logic (scoring rules, draft engine, waiver processing).
+- `src/utils/`: Helpers (validation, logging, time, ID generation).
+
+## Environment variables (planned)
+- `DB_URL` (PostgreSQL connection string)
+- `REDIS_URL`
+- `JWT_SECRET`
+- `PORT` (defaults to 8080)
+- `SSL_CERT_FILE` / `SSL_KEY_FILE` (optional HTTPS)
+- `ALLOWED_ORIGINS` (comma-separated CORS allowlist)
+
+## Next steps
+1. Add package/dependency setup for Drogon (FetchContent or system packages).
+2. Flesh out route handlers for auth, leagues, players, drafts, and lineups.
+3. Add integration tests for API endpoints and scoring logic.

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -1,0 +1,133 @@
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+#ifdef DROGON_FOUND
+#include <drogon/drogon.h>
+#endif
+
+#ifdef DROGON_FOUND
+namespace {
+std::optional<std::string> readEnv(const std::string &key) {
+    const char *val = std::getenv(key.c_str());
+    if (val == nullptr) {
+        return std::nullopt;
+    }
+    return std::string{val};
+}
+
+bool isAuthorized(const drogon::HttpRequestPtr &req, const std::string &secret) {
+    const auto authHeader = req->getHeader("authorization");
+    if (authHeader.size() < 8) {
+        return false;
+    }
+    constexpr std::string_view bearerPrefix = "Bearer ";
+    if (authHeader.rfind(bearerPrefix, 0) != 0) {
+        return false;
+    }
+    auto token = authHeader.substr(bearerPrefix.size());
+    return token == secret;
+}
+} // namespace
+#endif
+
+int main(int argc, char* argv[]) {
+#ifdef DROGON_FOUND
+    auto &app = drogon::app();
+
+    // Environment configuration
+    const auto port = readEnv("PORT").value_or("8080");
+    const auto jwtSecret = readEnv("JWT_SECRET");
+    const auto sslCert = readEnv("SSL_CERT_FILE");
+    const auto sslKey = readEnv("SSL_KEY_FILE");
+    const auto allowedOriginEnv = readEnv("ALLOWED_ORIGINS");
+
+    if (!jwtSecret.has_value()) {
+        std::cerr << "[security] JWT_SECRET is not set; secure endpoints will reject all requests." << std::endl;
+    }
+
+    // SSL enablement when certs are available
+    if (sslCert && sslKey) {
+        app.enableSSL(sslCert.value(), sslKey.value());
+        std::cout << "[security] SSL enabled with provided certificate and key." << std::endl;
+    } else {
+        std::cout << "[security] SSL not configured. For testing only. Provide SSL_CERT_FILE and SSL_KEY_FILE to enable HTTPS." << std::endl;
+    }
+
+    // Minimal CORS handling via post-routing advice
+    std::unordered_set<std::string> allowedOrigins;
+    if (allowedOriginEnv) {
+        // Comma-separated list of origins
+        std::string list = allowedOriginEnv.value();
+        std::size_t start = 0;
+        while (true) {
+            auto pos = list.find(',', start);
+            auto origin = list.substr(start, pos == std::string::npos ? std::string::npos : pos - start);
+            if (!origin.empty()) {
+                allowedOrigins.insert(origin);
+            }
+            if (pos == std::string::npos) {
+                break;
+            }
+            start = pos + 1;
+        }
+    }
+
+    app.registerPostHandlingAdvice([allowedOrigins](const drogon::HttpRequestPtr &req,
+                                                    const drogon::HttpResponsePtr &resp) {
+        if (!allowedOrigins.empty()) {
+            auto origin = req->getHeader("Origin");
+            if (allowedOrigins.find(origin) != allowedOrigins.end()) {
+                resp->addHeader("Access-Control-Allow-Origin", origin);
+            }
+        } else {
+            resp->addHeader("Access-Control-Allow-Origin", "*");
+        }
+        resp->addHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+        resp->addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    });
+
+    app.addListener("0.0.0.0", static_cast<unsigned short>(std::stoi(port)))
+        .setThreadNum(std::thread::hardware_concurrency())
+        .registerHandler("/health", [](const drogon::HttpRequestPtr&, std::function<void (const drogon::HttpResponsePtr &)> &&callback) {
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k200OK);
+            resp->setBody("ok");
+            callback(resp);
+        })
+        .registerHandler("/api/secure/ping",
+                         [jwtSecret](const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback) {
+                             auto resp = drogon::HttpResponse::newHttpResponse();
+                             if (!jwtSecret || !isAuthorized(req, jwtSecret.value())) {
+                                 resp->setStatusCode(drogon::k401Unauthorized);
+                                 resp->setBody("unauthorized");
+                                 callback(resp);
+                                 return;
+                             }
+                             resp->setStatusCode(drogon::k200OK);
+                             resp->setBody(R"({"status":"ok","scope":"secure"})");
+                             resp->addHeader("Content-Type", "application/json");
+                             callback(resp);
+                         },
+                         {drogon::Post, drogon::Get})
+        .registerHandler("/api/auth/validate",
+                         [jwtSecret](const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback) {
+                             auto resp = drogon::HttpResponse::newHttpResponse();
+                             const bool authorized = jwtSecret && isAuthorized(req, jwtSecret.value());
+                             resp->setStatusCode(authorized ? drogon::k200OK : drogon::k401Unauthorized);
+                             resp->setBody(authorized ? R"({"valid":true})" : R"({"valid":false})");
+                             resp->addHeader("Content-Type", "application/json");
+                             callback(resp);
+                         },
+                         {drogon::Get})
+        .run();
+#else
+    // Stub output to avoid hard dependency on Drogon in early scaffolding.
+    std::cout << "College Fantasy Football backend scaffold (Drogon not linked)." << std::endl;
+    std::cout << "Build with -DDROGON_FOUND=ON and link Drogon to run the HTTP server." << std::endl;
+#endif
+    return 0;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: ./backend
+    environment:
+      - PORT=8080
+      - JWT_SECRET=dev-secret-token
+      # - SSL_CERT_FILE=/certs/local.crt
+      # - SSL_KEY_FILE=/certs/local.key
+      # - ALLOWED_ORIGINS=http://localhost:8080,http://localhost:3000
+    ports:
+      - "8080:8080"
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,84 @@
+# College Fantasy Football Platform Architecture
+
+This document outlines a proposed architecture for a full-stack college fantasy football application targeting Division I FBS and FCS players.
+
+## Goals
+- Provide a slick, modern experience similar to popular NFL fantasy platforms.
+- Cover the full lifecycle: league creation, roster management, drafts, scoring, waivers, trades, and playoffs.
+- Handle the breadth of college players (FBS + FCS) with scalable ingestion and search.
+- Favor a maintainable, modular codebase with clear separation of concerns.
+
+## System Overview
+- **Frontend:** Lightweight HTML/CSS/JavaScript application served as static assets. Uses modular JavaScript for state management and fetch-based API calls. Can later adopt a component library if needed.
+- **Backend:** C++17+ service providing RESTful APIs and real-time updates (SSE/WebSockets for live scoring). The service exposes endpoints for auth, league management, drafts, rosters, schedules, scoring, and user preferences.
+- **Database:** PostgreSQL for transactional data (users, leagues, rosters, matchups). Redis for caching hot data (player lookups, live stats, session tokens).
+- **Data ingestion:** Scheduled jobs to pull game schedules, player pools, and live stats from external feeds. Normalize and store in a canonical schema.
+- **Deployment:** Containerized via Docker. CI to build/test the C++ service and lint the frontend assets.
+
+## Key Backend Components (C++)
+- **HTTP Server Framework:** Drogon (modern C++17, built-in routing, ORM support, WebSockets). Alternative: Pistache or Crow if Drogon is unavailable.
+- **Modules:**
+  - `auth`: signup/login, OAuth providers, session/token handling.
+  - `players`: player search, details, depth charts, injury updates.
+  - `leagues`: create/join leagues, scoring settings, roster rules.
+  - `drafts`: snake/auction drafts, queueing, pause/resume, commissioner controls.
+  - `lineups`: weekly lineup submissions and validation against roster rules.
+  - `matchups`: schedule generation, head-to-head scoring, playoffs/brackets.
+  - `waivers`: FAAB/priority processing, add/drop transactions.
+  - `scoring`: stat mapping, live scoring aggregation, historical box scores.
+  - `notifications`: email/push/web notifications for roster events and live scoring.
+  - `admin`: data quality dashboards and league support tools.
+
+## API Surface (Representative)
+- `POST /api/auth/signup`, `POST /api/auth/login`
+- `GET /api/players?query=` (name, team, position, conference filters)
+- `GET /api/leagues` (list/joinable), `POST /api/leagues` (create)
+- `GET /api/leagues/{id}`, `PATCH /api/leagues/{id}` (settings)
+- `POST /api/leagues/{id}/invite`, `POST /api/leagues/{id}/join`
+- `POST /api/leagues/{id}/draft/start`, `POST /api/leagues/{id}/draft/pick`
+- `POST /api/leagues/{id}/lineups/submit`, `POST /api/leagues/{id}/waivers`
+- `GET /api/leagues/{id}/matchups/week/{n}` (schedule + scores)
+- `GET /api/scores/live` (SSE/WebSocket stream for live scoring updates)
+
+## Data Model Notes
+- **Players:** keyed by an external player ID; includes metadata (team, position, class, conference, eligibility, injury status).
+- **Teams/Games:** normalized schedule table keyed by season/week/game. Supports doubleheaders and neutral-site flags.
+- **Leagues:** scoring settings (PPR, yardage bonuses, defensive scoring), roster slots, waiver type, draft type, playoff weeks.
+- **Rosters:** per-team roster table with slot enforcement and transaction history.
+- **Matchups:** head-to-head pairings, weekly scores, playoff brackets.
+- **Stats ingestion:** pipeline to transform vendor-specific stats into normalized categories; stored per game and aggregated weekly.
+
+## Draft & Scoring Considerations
+- Draft UI should support search, queueing, and autopick if a user is disconnected.
+- Scoring should be configurable by league and re-calculable if rules change midseason.
+- Live scoring should batch updates to limit load, with per-league throttling.
+- Injury news and depth chart changes should be cached and flagged for roster validation.
+
+## Observability & Reliability
+- Structured logging with request IDs and user/league context.
+- Metrics (latency, throughput, error rates, draft/waiver throughput) via Prometheus/OpenTelemetry exporters.
+- Health checks for dependencies (DB, cache, message bus for ingestion).
+- Rate limiting and input validation at the edge.
+
+## Security
+- HTTPS everywhere; signed JWTs or opaque tokens stored server-side (Redis) for sessions.
+- RBAC for commissioner vs. team managers vs. read-only members.
+- Audit logs for commissioner actions and roster changes.
+
+## Roadmap (high level)
+1. Scaffold C++ backend with Drogon, auth skeleton, and health check endpoint.
+2. Implement player search and league creation APIs backed by PostgreSQL.
+3. Build draft engine (snake) with WebSocket updates; add lineup submission.
+4. Add waiver processing and weekly matchup scoring.
+5. Integrate live scoring ingestion and notification channels.
+6. Harden for scale: caching, rate limiting, background jobs, and observability.
+
+## Local Development
+- Build the backend via CMake (example provided in `backend/README.md`).
+- Serve the frontend from `frontend/` during development with a simple static server.
+- Use Docker Compose to run PostgreSQL and Redis locally (future addition).
+
+## Open Questions
+- Preferred data vendor(s) for comprehensive FBS/FCS stats.
+- Depth chart/injury feed availability and latency requirements.
+- Whether to support IDP (individual defensive players) and special teams scoring at launch.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,5 @@
+# Simple static site container using nginx
+FROM nginx:1.27-alpine
+WORKDIR /usr/share/nginx/html
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,87 @@
+const apiBase = '/api';
+
+const cta = document.getElementById('cta');
+cta.addEventListener('click', () => {
+  alert('League creation flow coming soon.');
+});
+
+const liveScoresEl = document.getElementById('live-scores');
+const searchForm = document.getElementById('search-form');
+const searchInput = document.getElementById('search-input');
+const searchResultsEl = document.getElementById('search-results');
+const leagueSummaryEl = document.getElementById('league-summary');
+
+async function fetchLiveScores() {
+  liveScoresEl.textContent = 'Loading live scores...';
+  try {
+    const resp = await fetch(`${apiBase}/scores/live`);
+    if (!resp.ok) throw new Error('Live scores unavailable');
+    const data = await resp.json();
+    renderLiveScores(data);
+  } catch (err) {
+    liveScoresEl.textContent = 'Live scores will appear here during game time.';
+  }
+}
+
+function renderLiveScores(scores = []) {
+  if (!scores.length) {
+    liveScoresEl.textContent = 'No games in progress.';
+    return;
+  }
+  liveScoresEl.innerHTML = scores.map(s => `
+    <div class="row">
+      <div>
+        <strong>${s.away} @ ${s.home}</strong>
+        <div class="muted">Q${s.quarter} - ${s.clock || '00:00'}</div>
+      </div>
+      <div class="score">${s.awayScore} - ${s.homeScore}</div>
+    </div>
+  `).join('');
+}
+
+searchForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const term = searchInput.value.trim();
+  if (!term) return;
+  searchResultsEl.textContent = 'Searching...';
+  try {
+    const resp = await fetch(`${apiBase}/players?query=${encodeURIComponent(term)}`);
+    if (!resp.ok) throw new Error('Search failed');
+    const data = await resp.json();
+    renderSearchResults(data);
+  } catch (err) {
+    searchResultsEl.textContent = 'Unable to fetch players right now.';
+  }
+});
+
+function renderSearchResults(players = []) {
+  if (!players.length) {
+    searchResultsEl.textContent = 'No players found.';
+    return;
+  }
+  searchResultsEl.innerHTML = players.slice(0, 10).map(p => `
+    <div class="row">
+      <div>
+        <strong>${p.name}</strong> — ${p.team} (${p.position})
+        <div class="muted">${p.conference || 'Conference TBD'} • ${p.class || 'Class TBD'}</div>
+      </div>
+      <button class="button" data-player="${p.id}">Add to queue</button>
+    </div>
+  `).join('');
+}
+
+function loadLeagueSummary() {
+  leagueSummaryEl.innerHTML = `
+    <div class="row">
+      <div>
+        <strong>League features</strong>
+        <div class="muted">Create leagues, customize scoring, draft players, and manage lineups.</div>
+      </div>
+      <a class="button" href="#">Sign in</a>
+    </div>
+  `;
+}
+
+// Initial bootstrap
+fetchLiveScores();
+loadLeagueSummary();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>College Fantasy Football</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <h1>College Fantasy Football</h1>
+      <p class="subtitle">FBS &amp; FCS coverage with a modern fantasy experience.</p>
+      <button id="cta" class="button button--primary">Create a League</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="card">
+      <h2>Live Scores</h2>
+      <div id="live-scores" class="list">Loading live scores...</div>
+    </section>
+
+    <section class="card">
+      <h2>Player Search</h2>
+      <form id="search-form" class="search">
+        <input id="search-input" type="search" placeholder="Search players (name, team, position)" />
+        <button class="button" type="submit">Search</button>
+      </form>
+      <div id="search-results" class="list">Try searching for a player.</div>
+    </section>
+
+    <section class="card">
+      <h2>Your League</h2>
+      <div id="league-summary" class="list">Sign in to see your league.</div>
+    </section>
+  </main>
+
+  <footer class="footer">Built for college fantasy managers.</footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,101 @@
+:root {
+  --bg: #0b1021;
+  --card: #11162b;
+  --text: #e7eaf6;
+  --muted: #9aa3c2;
+  --accent: #45d19f;
+  --accent-2: #6c8bff;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(145deg, #0b1021, #0c1430);
+  color: var(--text);
+}
+
+.hero {
+  padding: 64px 24px;
+  background: radial-gradient(circle at 20% 20%, rgba(108, 139, 255, 0.25), transparent 35%),
+              radial-gradient(circle at 80% 0%, rgba(69, 209, 159, 0.2), transparent 30%),
+              var(--bg);
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 { font-size: 2.75rem; margin-bottom: 8px; }
+.subtitle { color: var(--muted); font-size: 1.1rem; margin-top: 0; }
+
+.layout {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  padding: 24px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+}
+
+.card h2 { margin-top: 0; }
+
+.list {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 12px;
+  min-height: 120px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.button {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--accent-2);
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.button:hover { background: rgba(108, 139, 255, 0.15); }
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent-2), var(--accent));
+  border: none;
+  color: #0b1021;
+  box-shadow: 0 8px 30px rgba(69, 209, 159, 0.35);
+}
+
+.button--primary:hover { transform: translateY(-1px); }
+
+.search { display: flex; gap: 8px; }
+.search input {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.footer {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+}
+
+a { color: var(--accent); }

--- a/frontend/test.html
+++ b/frontend/test.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Backend Security Check</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    .status { margin-top: 12px; font-weight: 600; }
+    .ok { color: #45d19f; }
+    .fail { color: #ff7b7b; }
+  </style>
+</head>
+<body>
+  <main class="layout" style="max-width:720px">
+    <section class="card">
+      <h2>Secure Endpoint Test</h2>
+      <p class="subtitle">Calls <code>/api/secure/ping</code> using the supplied bearer token.</p>
+      <form id="ping-form" class="search">
+        <input id="token" type="text" placeholder="Enter JWT secret or bearer token" required />
+        <button class="button button--primary" type="submit">Send Ping</button>
+      </form>
+      <div id="result" class="status muted">Awaiting request...</div>
+    </section>
+  </main>
+  <script>
+    const form = document.getElementById('ping-form');
+    const tokenInput = document.getElementById('token');
+    const result = document.getElementById('result');
+    const backend = window.location.origin.replace('3000', '8080');
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const token = tokenInput.value.trim();
+      if (!token) return;
+      result.textContent = 'Requesting secure ping...';
+      result.className = 'status muted';
+      try {
+        const resp = await fetch(`${backend}/api/secure/ping`, {
+          headers: { 'Authorization': token.startsWith('Bearer ') ? token : `Bearer ${token}` }
+        });
+        const text = await resp.text();
+        if (resp.ok) {
+          result.textContent = `Success: ${text}`;
+          result.className = 'status ok';
+        } else {
+          result.textContent = `Unauthorized: ${text}`;
+          result.className = 'status fail';
+        }
+      } catch (err) {
+        result.textContent = 'Request failed. Is the backend running on 8080?';
+        result.className = 'status fail';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add security-oriented backend endpoints with JWT secret validation, CORS headers, and optional SSL configuration
- provide Dockerfiles and compose setup for running backend and frontend locally on localhost
- include frontend test page to exercise the secure ping endpoint with bearer tokens

## Testing
- cmake -S backend -B backend/build -DDROGON_FOUND=OFF
- cmake --build backend/build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c54d282e08328832868da776aa363)