### PR TITLE
Handle missing pwsh path lookup in installer

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -35,8 +35,13 @@ if (-not (Is-Administrator)) {
   }
 
   # prefer pwsh (PowerShell Core), fall back to Windows PowerShell (powershell.exe)
-  $elevExe = (Get-Command pwsh -ErrorAction SilentlyContinue).Path
-  if (-not $elevExe) { $elevExe = (Get-Command powershell -ErrorAction SilentlyContinue).Path }
+  $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+  if ($pwshCmd) { $elevExe = $pwshCmd.Path }
+
+  if (-not $elevExe) {
+    $psCmd = Get-Command powershell -ErrorAction SilentlyContinue
+    if ($psCmd) { $elevExe = $psCmd.Path }
+  }
 
   if (-not $elevExe) {
     Write-Host "Error: neither 'pwsh' nor 'powershell' was found to re-launch the script elevated. Run this script from an elevated session or install PowerShell Core." -ForegroundColor Red


### PR DESCRIPTION
## Summary
- guard elevation command selection so pwsh or powershell is only used when found
- prevent null Path access when PowerShell executables are missing from PATH

## Testing
- not run (script change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6ec0623c8328b40066c2385c6c9f)