### PR TITLE
Build Drogon from source in backend Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,8 +10,16 @@ RUN apt-get update && apt-get install -y \
     uuid-dev \
     zlib1g-dev \
     libssl-dev \
-    libdrogon-dev \
+    libbrotli-dev \
+    libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Build Drogon from source (libdrogon-dev is not available on Debian Bookworm)
+RUN git clone --branch v1.9.7 --depth 1 https://github.com/drogonframework/drogon.git /tmp/drogon \
+    && cmake -S /tmp/drogon -B /tmp/drogon/build -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build /tmp/drogon/build --target install -- -j$(nproc) \
+    && ldconfig \
+    && rm -rf /tmp/drogon
 
 WORKDIR /app
 COPY . /app
@@ -20,7 +28,14 @@ RUN cmake -S . -B build -DDROGON_FOUND=ON \
     && cmake --build build --target college_ff_server -- -j$(nproc)
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y libssl3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    libjsoncpp25 \
+    libuuid1 \
+    zlib1g \
+    libbrotli1 \
+    libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /srv
 COPY --from=build /app/build/college_ff_server /srv/college_ff_server
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- add Drogon source build to the backend Docker image to replace missing libdrogon-dev on Debian Bookworm
- include Brotli and SQLite build dependencies and runtime shared libraries in the slim stage

## Testing
- not run (Docker build not executed in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7ea463908328bc3e2c7841b083e4)