### PR TITLE
Update backend Dockerfile build setup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,41 +1,43 @@
 # Backend container for local testing
-FROM debian:bookworm as build
+FROM debian:bookworm AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     git \
+    pkg-config \
     libjsoncpp-dev \
     uuid-dev \
     zlib1g-dev \
     libssl-dev \
     libbrotli-dev \
     libsqlite3-dev \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
-# Build Drogon from source (libdrogon-dev is not available on Debian Bookworm)
-RUN git clone --branch v1.9.7 --depth 1 https://github.com/drogonframework/drogon.git /tmp/drogon \
-    && cmake -S /tmp/drogon -B /tmp/drogon/build -DCMAKE_BUILD_TYPE=Release \
-    && cmake --build /tmp/drogon/build --target install -- -j$(nproc) \
-    && ldconfig \
-    && rm -rf /tmp/drogon
+# Build Drogon from source (Bookworm doesn't ship libdrogon-dev)
+RUN git clone --branch v1.9.7 --depth 1 --recurse-submodules \
+      https://github.com/drogonframework/drogon.git /tmp/drogon \
+ && cmake -S /tmp/drogon -B /tmp/drogon/build -DCMAKE_BUILD_TYPE=Release \
+ && cmake --build /tmp/drogon/build --target install -- -j"$(nproc)" \
+ && ldconfig \
+ && rm -rf /tmp/drogon
 
 WORKDIR /app
 COPY . /app
 
-RUN cmake -S . -B build -DDROGON_FOUND=ON \
-    && cmake --build build --target college_ff_server -- -j$(nproc)
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local \
+ && cmake --build build --target college_ff_server -- -j"$(nproc)"
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     libjsoncpp25 \
     libuuid1 \
     zlib1g \
     libbrotli1 \
     libsqlite3-0 \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /srv
 COPY --from=build /app/build/college_ff_server /srv/college_ff_server
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- add missing build prerequisites and submodule checkout for Drogon
- build both Drogon and the application in release mode with an explicit prefix path
- trim runtime dependencies by using non-recommended packages during installation

## Testing
- `docker build -t college-ff-backend backend` *(fails: docker not available in execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c89d804b8832882bf91e33d98b7a6)