### PR TITLE
Refine Dockerfile for frontend and backend builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,61 @@
-# GCC support can be specified at major, minor, or micro version
-# (e.g. 8, 8.2 or 8.2.0).
-# See https://hub.docker.com/r/library/gcc/ for all supported GCC
-# tags from Docker Hub.
-# See https://docs.docker.com/samples/library/gcc/ for more on how to use this image
-FROM gcc:latest
+# Frontend: static site served by nginx
+FROM nginx:1.27-alpine AS frontend
+WORKDIR /usr/share/nginx/html
+COPY frontend/ /usr/share/nginx/html
+EXPOSE 80
 
-# These commands copy your files into the specified directory in the image
-# and set that as the working location
-COPY . /usr/src/myapp
-WORKDIR /usr/src/myapp
+# Backend: Drogon-based server build
+FROM debian:bookworm AS backend-build
 
-# This command compiles your app using GCC, adjust for your source code
-RUN g++ -o myapp main.cpp
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    cmake \
+    git \
+    pkg-config \
+    libjsoncpp-dev \
+    uuid-dev \
+    zlib1g-dev \
+    libssl-dev \
+    libbrotli-dev \
+    libsqlite3-dev \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 
-# This command runs your application, comment out this line to compile only
-CMD ["./myapp"]
+# Build Drogon from source (Bookworm doesn't ship libdrogon-dev)
+RUN git config --global http.version HTTP/1.1 \
+ && git clone --branch v1.9.7 --depth 1 https://github.com/drogonframework/drogon.git /tmp/drogon \
+ && cd /tmp/drogon \
+ && git submodule update --init --recursive --depth 1 \
+ && cmake -S /tmp/drogon -B /tmp/drogon/build -DCMAKE_BUILD_TYPE=Release \
+ && cmake --build /tmp/drogon/build --target install -- -j"$(nproc)" \
+ && ldconfig \
+ && rm -rf /tmp/drogon
+
+WORKDIR /app/backend
+COPY backend/ /app/backend
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local \
+    -DENABLE_DROGON=ON \
+ && cmake --build build --target college_ff_server -- -j"$(nproc)"
+
+FROM debian:bookworm-slim AS backend
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    libjsoncpp25 \
+    libuuid1 \
+    zlib1g \
+    libbrotli1 \
+    libsqlite3-0 \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /srv
+COPY --from=backend-build /app/backend/build/college_ff_server /srv/college_ff_server
+
+EXPOSE 8080
+ENV PORT=8080
+CMD ["/srv/college_ff_server"]
 
 LABEL Name=collegefantasyfootball Version=0.0.1

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -5,13 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Drogon can be fetched via FetchContent or provided by the system.
-# To keep this scaffold lightweight, we do not fetch dependencies automatically.
-# Define DROGON_FOUND to ON if Drogon is available in your environment.
-
-if (DROGON_FOUND)
-    find_package(Drogon CONFIG REQUIRED)
-endif()
+option(ENABLE_DROGON "Build with Drogon HTTP framework" ON)
 
 add_executable(college_ff_server
     src/main.cpp
@@ -19,8 +13,10 @@ add_executable(college_ff_server
 
 target_include_directories(college_ff_server PRIVATE src)
 
-if (DROGON_FOUND)
+if (ENABLE_DROGON)
+    find_package(Drogon CONFIG REQUIRED)
     target_link_libraries(college_ff_server PRIVATE Drogon::Drogon)
+    target_compile_definitions(college_ff_server PRIVATE DROGON_FOUND)
 else()
-    message(WARNING "Drogon not found; building a stub server without HTTP bindings.")
+    message(WARNING "ENABLE_DROGON=OFF; building a stub server without HTTP bindings.")
 endif()

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,7 +31,7 @@ RUN git config --global http.version HTTP/1.1 \
 WORKDIR /app
 COPY . /app
 
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local \
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_DROGON=ON \
  && cmake --build build --target college_ff_server -- -j"$(nproc)"
 
 FROM debian:bookworm-slim

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
 
     // SSL enablement when certs are available
     if (sslCert && sslKey) {
-        app.enableSSL(sslCert.value(), sslKey.value());
+        app.setSSLFiles(sslCert.value(), sslKey.value());
         std::cout << "[security] SSL enabled with provided certificate and key." << std::endl;
     } else {
         std::cout << "[security] SSL not configured. For testing only. Provide SSL_CERT_FILE and SSL_KEY_FILE to enable HTTPS." << std::endl;


### PR DESCRIPTION
## Summary
- replace placeholder GCC image with multi-stage build for nginx frontend and Drogon backend
- build backend using Debian bookworm with Drogon compiled from source
- produce slim runtime image for the backend server
- enable Drogon builds by default via CMake option and compile definitions
- update SSL configuration to use Drogon setSSLFiles API for HTTPS setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8d644ac48328888ab1cc1bd2bdd0)