### PR TITLE
Add login endpoint and sign-in flow for league creation

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
       <a class="nav__link" href="#">Players</a>
     </nav>
     <div class="nav__actions">
-      <button class="button button--ghost">Sign in</button>
+      <button class="button button--ghost" id="nav-sign-in" type="button">Sign in</button>
       <button class="button button--primary js-open-league">Create League</button>
     </div>
   </div>
@@ -123,6 +123,21 @@
 
     <section class="card">
       <h2>Your League</h2>
+      <form id="sign-in-form" class="form">
+        <div class="field">
+          <span>Email</span>
+          <input id="sign-in-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" />
+        </div>
+        <div class="field">
+          <span>Access token</span>
+          <input id="sign-in-token" type="password" name="token" placeholder="dev-secret-token" required />
+        </div>
+        <div class="actions">
+          <button class="button button--ghost" type="button" id="prefill-token">Use dev token</button>
+          <button class="button button--primary" type="submit">Sign in</button>
+        </div>
+      </form>
+      <div id="sign-in-status" class="muted small" role="status"></div>
       <div id="league-summary" class="list">Sign in to see your league.</div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add shared CORS helpers and OPTIONS responses plus a lightweight /api/auth/login endpoint
- wire the frontend sign-in form to request a token, persist it, and reuse it for league creation
- update the UI with a sign-in form and helpful defaults for the development token

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d84bcc70883289566392ab9b4c0e1)