### PR TITLE
Update frontend nginx and backend base images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Backend container for local testing
-FROM debian:bookworm AS build
+FROM debian:13.2-slim AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -35,7 +35,7 @@ COPY . /app
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_DROGON=ON \
  && cmake --build build --target college_ff_server -- -j"$(nproc)"
 
-FROM debian:bookworm-slim
+FROM debian:13.2-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3 \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Simple static site container using nginx
-FROM nginx:1.27-alpine
+FROM nginx:1.28-alpine-slim
 WORKDIR /usr/share/nginx/html
 COPY . /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- bump the frontend container to nginx:1.28-alpine-slim
- update backend build and runtime to debian:13.2-slim (trixie) for newer fixes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950329b38788328bdd3d54b217578a7)