### PR TITLE
Use bookworm base images for backend service

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Backend container for local testing
-FROM debian:13.2-slim AS build
+FROM debian:bookworm AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -35,7 +35,7 @@ COPY . /app
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_DROGON=ON \
  && cmake --build build --target college_ff_server -- -j"$(nproc)"
 
-FROM debian:13.2-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3 \


### PR DESCRIPTION
## Summary
- switch the backend build stage to Debian bookworm to align with available package versions
- use Debian bookworm-slim for the runtime image so libjsoncpp25 resolves during docker-compose builds

## Testing
- ⚠️ `docker run --rm debian:bookworm-slim sh -c "apt-get update && apt-get install -y --no-install-recommends libjsoncpp25 && echo 'installed'"` (not run successfully: docker is unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695035c3823c8328a98fb8a3c1b307f1)